### PR TITLE
Node, row and lookup block types

### DIFF
--- a/src/schema/constraint/0_3_0/perf_block_constraint.json
+++ b/src/schema/constraint/0_3_0/perf_block_constraint.json
@@ -6,7 +6,10 @@
       "type": "string",
       "enum": [
         "paragraph",
-        "graft"
+        "graft",
+        "row",
+        "node",
+        "lookup"
       ]
     },
     "content": {
@@ -39,7 +42,9 @@
   "if": {
     "properties": {
       "type": {
-        "enum": ["graft"]
+        "enum": [
+          "graft"
+        ]
       }
     }
   },
@@ -63,13 +68,122 @@
     }
   },
   "else": {
-    "properties": {
-      "subtype": {
-        "type": "string",
-        "pattern": "^usfm:"
+    "if": {
+      "properties": {
+        "type": {
+          "enum": ["row"]
+        }
+      }
+    },
+    "then": {
+      "properties": {
+        "subtype": {
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "row:heading",
+                "row:body"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "else": {
+      "if": {
+        "properties": {
+          "type": {"enum": ["node"]}
+        }
+      },
+      "then": {
+        "properties": {
+          "subtype": {
+            "type": "string",
+            "oneOf": [
+              {"enum":  ["node"]},
+              {
+                "pattern": "^x-\\S+$"
+              }
+            ]
+          },
+          "atts": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "parent": {
+                "type": "string"
+              },
+              "children": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "else": {
+        "if": {
+          "properties": {
+            "type": {"enum": ["lookup"]}
+          }
+        },
+        "then": {
+          "properties": {
+            "subtype": {
+              "type": "string",
+              "oneOf": [
+                {"enum":  ["lookup"]},
+                {
+                  "pattern": "^x-\\S+$"
+                }
+              ]
+            },
+            "atts": {
+              "type": "object",
+              "properties": {
+                "primary": {
+                  "type": "string"
+                },
+                "secondary": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "primary"
+              ],
+              "additionalProperties": false
+            }
+
+          }
+        },
+        "else": {
+          "properties": {
+            "subtype": {
+              "type": "string",
+              "oneOf": [
+                {
+                  "pattern": "^usfm:"
+                },
+                {
+                  "pattern": "^x-\\S+$"
+                }
+              ]
+            }
+          }
+        }
       }
     }
   }
 }
-
-

--- a/src/schema/constraint/0_3_0/perf_block_constraint.json
+++ b/src/schema/constraint/0_3_0/perf_block_constraint.json
@@ -103,7 +103,7 @@
             "oneOf": [
               {"enum":  ["node"]},
               {
-                "pattern": "^x-\\S+$"
+                "pattern": "^x-\\S{1,256}$"
               }
             ]
           },
@@ -143,7 +143,7 @@
               "oneOf": [
                 {"enum":  ["lookup"]},
                 {
-                  "pattern": "^x-\\S+$"
+                  "pattern": "^x-\\S{1,256}$"
                 }
               ]
             },
@@ -177,7 +177,7 @@
                   "pattern": "^usfm:"
                 },
                 {
-                  "pattern": "^x-\\S+$"
+                  "pattern": "^x-\\S{1,256}$"
                 }
               ]
             }

--- a/src/schema/constraint/0_3_0/perf_document_constraint.json
+++ b/src/schema/constraint/0_3_0/perf_document_constraint.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "version 0.2.0",
+  "$comment": "version 0.3.0",
   "$id": "https://github.com/Proskomma/proskomma-json-tools/tree/main/src/schema/constraint/0_3_0/perf_document_constraint.json",
   "type": "object",
   "properties": {

--- a/src/schema/structure/0_3_0/block_structure.json
+++ b/src/schema/structure/0_3_0/block_structure.json
@@ -9,6 +9,9 @@
       "description": "The type of block",
       "enum": [
         "paragraph",
+        "row",
+        "node",
+        "lookup",
         "graft"
       ]
     },
@@ -79,7 +82,10 @@
     "properties": {
       "type": {
         "enum": [
-          "paragraph"
+          "paragraph",
+          "row",
+          "node",
+          "lookup"
         ]
       }
     }

--- a/test/code/validator.cjs
+++ b/test/code/validator.cjs
@@ -300,3 +300,28 @@ test(
         }
     },
 );
+
+test(
+    `validate non-para PERF block types (${testGroup})`,
+    async function (t) {
+        try {
+            t.plan(2);
+            const perf = fse.readJsonSync(
+                path.resolve(
+                    path.join(__dirname, '..', 'test_data', 'validation', 'all_block_types_perf.json')
+                )
+            )
+            const validator = new Validator();
+            const validation = validator.validate(
+                'constraint',
+                'perfDocument',
+                '0.3.0',
+                perf
+            );
+            t.ok(validation.isValid);
+            t.equal(validation.errors, null);
+        } catch (err) {
+            console.log(err);
+        }
+    },
+);

--- a/test/test_data/validation/all_block_types_perf.json
+++ b/test/test_data/validation/all_block_types_perf.json
@@ -1,0 +1,73 @@
+{
+  "schema": {
+    "structure": "flat",
+    "structure_version": "0.3.0",
+    "constraints": [
+      {
+        "name": "perf",
+        "version": "0.3.0"
+      }
+    ]
+  },
+  "metadata": {
+    "translation": {
+      "id": "frob",
+      "tags": [],
+      "selectors": {},
+      "other_stuff_key": ""
+    },
+    "document": {
+      "chapters": "1-3",
+      "tags": [],
+      "other_stuff_key_including_headers": ""
+    }
+  },
+  "sequences": {
+    "foobaa": {
+      "type": "main",
+      "blocks": [
+        {
+          "type": "row",
+          "subtype": "row:body",
+          "content": [
+            {
+              "type": "wrapper",
+              "subtype": "row:cell",
+              "content": [
+                "Cell content goes here"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "node",
+          "subtype": "x-noun-phrase",
+          "atts": {
+            "id": "abcde",
+            "parent": "xyz",
+            "children": ["def", "ghi"]
+          },
+          "content": [
+            "Node content goes here"
+          ]
+        },
+        {
+          "type": "lookup",
+          "subtype": "lookup",
+          "atts": {
+            "primary": "thummim",
+            "secondary": [
+              "worship",
+              "ot",
+              "funky"
+            ]
+          },
+          "content": [
+            "Node content goes here"
+          ]
+        }
+      ]
+    }
+  },
+  "main_sequence_id": "foobaa"
+}


### PR DESCRIPTION
These schema changes support the following alternatives to paragraphs:
- node (for trees)
- row (for tables)
- lookup (for key-value data)

There's basic schema checking of these new types. We need to fill out enums for various values (and also for paragraphs which, eventually, will need to allow non-USFM content). But I think this is enough to let us start working towards Proskomma support.

Tests pass.