### PR TITLE
Add and use unresolved graft events

### DIFF
--- a/src/PerfRenderFromJson.js
+++ b/src/PerfRenderFromJson.js
@@ -8,7 +8,6 @@ class PerfRenderFromJson extends ProskommaRender {
             throw new Error(`Must provide srcJson`);
         }
         this.srcJson = spec.srcJson;
-        this.ignoreMissingSequences = spec.ignoreMissingSequences || false;
     }
 
     renderDocument1({docId, config, context, workspace, output}) {
@@ -53,15 +52,13 @@ class PerfRenderFromJson extends ProskommaRender {
             }
             if (block.type === 'graft') {
                 if (block.target && !this.srcJson.sequences[block.target]) {
-                    if (this.ignoreMissingSequences) {
-                        continue;
-                    } else {
-                        throw new Error(`Sequence '${block.target} not found and ignoreMissingSequences not set'`);
-                    }
+                    context.sequences[0].block.target = block.target;
+                    this.renderEvent('unresolvedBlockGraft', environment);
+                } else {
+                    context.sequences[0].block.target = block.target;
+                    context.sequences[0].block.isNew = block.new || false;
+                    this.renderEvent('blockGraft', environment);
                 }
-                context.sequences[0].block.target = block.target;
-                context.sequences[0].block.isNew = block.new || false;
-                this.renderEvent('blockGraft', environment);
             } else {
                 this.renderEvent('startParagraph', environment);
                 this.renderContent(block.content, environment);
@@ -125,10 +122,8 @@ class PerfRenderFromJson extends ProskommaRender {
         } else if (elementContext.type === "graft") {
             if (element.target) {
                 if (element.target && !this.srcJson.sequences[element.target]) {
-                    if (this.ignoreMissingSequences) {
-                    } else {
-                        throw new Error(`Sequence '${element.target} not found and ignoreMissingSequences not set'`);
-                    }
+                    this.renderEvent('unresolvedInlineGraft', environment);
+                    return;
                 }
             }
             this.renderEvent('inlineGraft', environment);

--- a/src/ProskommaRender.js
+++ b/src/ProskommaRender.js
@@ -14,11 +14,13 @@ class ProskommaRender {
             "endDocument",
             "startSequence",
             "endSequence",
+            "unresolvedBlockGraft",
             "blockGraft",
             "startParagraph",
             "endParagraph",
             "metaContent",
             "mark",
+            "unresolvedInlineGraft",
             "inlineGraft",
             "startWrapper",
             "endWrapper",
@@ -107,6 +109,9 @@ class ProskommaRender {
                     break;
                 }
             }
+        }
+        if (['unresolvedBlockGraft', 'unresolvedInlineGraft'].includes(event) && this.actions[event].length === 0) {
+            throw new Error(`No action for ${event} graft event in ${context.sequences.length > 0 ? context.sequences[0].type : "no"} sequence: add an action or fix your data!`)
         }
         if (!found && this.debugLevel > 1) {
             console.log(`${"    ".repeat(context.sequences.length)}    No matching action`);

--- a/test/code/renderPerfFromJson.cjs
+++ b/test/code/renderPerfFromJson.cjs
@@ -114,7 +114,7 @@ test(
             const cl = new PerfRenderFromJson({srcJson: perf, actions: identityActions});
             const output = {};
             t.doesNotThrow(() => cl.renderDocument({docId: "", config: {}, output}));
-            // console.log(JSON.stringify(output, null, 2));
+            // console.log(JSON.stringify(output.perf, null, 2));
             t.ok(equal(perf, output.perf));
         } catch (err) {
             console.log(err);
@@ -131,7 +131,18 @@ test(
             const cl = new PerfRenderFromJson({
                 srcJson: perf,
                 ignoreMissingSequences: true,
-                actions: identityActions
+                actions: mergeActions([
+                    {
+                        unresolvedBlockGraft: [
+                            {
+                                description: "Ignore unresolved block grafts",
+                                test: () => false,
+                                action: () => {}
+                            }
+                        ]
+                    },
+                    identityActions
+                ])
             });
             const output = {};
             t.doesNotThrow(() => cl.renderDocument({docId: "", config: {}, output}));
@@ -153,7 +164,7 @@ test(
                 actions: identityActions
             });
             const output = {};
-            t.throws(() => cl.renderDocument({docId: "", config: {}, output}), /not found.*not set/);
+            t.throws(() => cl.renderDocument({docId: "", config: {}, output}), /No action for unresolved.*fix your data/);
         } catch (err) {
             console.log(err);
         }


### PR DESCRIPTION
This PR unrolls the previous ignoreMissingGrafts strategy, because in some cases missing grafts need to be handled.

The new strategy adds
- unresolvedBlockGraft
- unresolvedInlineGraft

to ProskommaRender, which throws an error if these events are called and if no action is set for them. The events may be ignored by adding an empty action (as in the unit test) or handled in some other way.

I've only added these events to PerfRenderFromJson because SOFRIA has all grafts inline, and because PerfRenderFromProskomma should always provide all the grafts (since the events are generated from Proskomma internals, not arbitrary JSON).

Tests pass.