### PR TITLE
Render footnotes as normal para; fix extra commas in footnotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proskomma-json-tools",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Tools for working with Proskomma-derived formats such as PERF and SOFRIA",
   "main": "dist/index.js",
   "directories": {

--- a/src/render/sofria2web/renderActions/sofria2web.js
+++ b/src/render/sofria2web/renderActions/sofria2web.js
@@ -252,7 +252,7 @@ const sofria2WebActions = {
                 };
                 if (context.sequences[0].element.subType === 'cell') {
                     pushed.atts = context.sequences[0].element.atts
-                };
+                }
 
                 workspace.currentIndex += 1
                 workspace.paraContentStack.unshift(
@@ -294,7 +294,15 @@ const sofria2WebActions = {
 
                 const popped = workspace.paraContentStack.shift();
 
-                workspace.paraContentStack[0].content.push(config.renderers.wrapper(popped.subType === 'cell' ? popped.atts : {}, popped.subType, popped.content, workspace.currentIndex));
+                workspace.paraContentStack[0]
+                    .content.push(
+                        config.renderers.wrapper(
+                            popped.subType === 'cell' ? popped.atts : {},
+                            popped.subType,
+                            popped.content,
+                            workspace.currentIndex
+                        )
+                );
 
             }
         },
@@ -344,8 +352,6 @@ const sofria2WebActions = {
             action: ({ config, context, workspace }) => {
 
                 const element = context.sequences[0].element;
-                //const renderedText = config.renderers.text(element.text);
-                //workspace.paraContentStack[0].content.push(renderedText);
                 element.text.split(" ").map((w, id) => {
                     workspace.currentIndex += 1
                     const renderedText = config.renderers.text((id === element.text.split(" ").length - 1) ? w : w + " ", workspace.currentIndex)

--- a/src/render/sofria2web/sofria2html.js
+++ b/src/render/sofria2web/sofria2html.js
@@ -1,29 +1,9 @@
-const inlineElement =  props => `<span
-            style={{
-                class: props.class,
-                paddingLeft: "0.5em",
-                paddingRight: "0.5em",
-                backgroundColor: "#CCC",
-                marginTop: "1em",
-                marginBottom: "1em"
-            }}
-            onClick={toggleDisplay}
-        >
-            ${props.children}
-        </span>`;
-
 const renderers = {
     text: text => `${text}`,
     chapter_label: number => `<span class="marks_chapter_label">${number}</span>`,
     verses_label: number => `<span class="marks_verses_label">${number}</span>`,
     paragraph: (subType, content, footnoteNo) => {
-        return ["usfm:f", "usfm:x"].includes(subType) ?
-            inlineElement({
-                class: `paras_usfm_${subType.split(':')[1]}`,
-                // linkText: (subType === "usfm:f") ? footnoteNo : "*",
-                children: content.join('')
-            })
-            : `<p class="${`paras_usfm_${subType.split(':')[1]}`}">${content.join('')}</p>`
+        return `<p class="${`paras_usfm_${subType.split(':')[1]}`}">${content.join('')}</p>`
     },
     wrapper: (atts, subType, content) => subType === 'cell' ?
 
@@ -33,7 +13,7 @@ const renderers = {
             `<th colspan=${atts.nCols} style="text-align:${atts.alignment}">${content.join("")}</th>`
         :
 
-        `<span class="${`paras_usfm_${subType.split(':')[1]}`}">${content}</span>`,
+        `<span class="${`paras_usfm_${subType.split(':')[1]}`}">${content.join("")}</span>`,
     wWrapper: (atts, content) => Object.keys(atts).length === 0 ?
         content :
         `<span

--- a/test/code/test_renderHtml.cjs
+++ b/test/code/test_renderHtml.cjs
@@ -128,17 +128,18 @@ test(`No extra commas around word markup (${testGroup})`, (t) => {
 test(`Footnote (${testGroup})`, (t) => {
     t.plan(3);
     try {
-        const pk7 = new Proskomma();
+        const pk8 = new Proskomma();
+        //eng_francl_mrk
         const usfm = fse.readFileSync(path.resolve(path.join('./', 'test', 'test_data', 'usfms', 'eng_francl_mrk.usfm'))).toString();
-        pk7.importDocument({ 'lang': 'eng', 'abbr': 'francl' }, 'usfm', usfm);
-        const docId = pk7.gqlQuerySync('{documents { id } }').data.documents[0].id;
-        const cl = new SofriaRenderFromProskomma({ proskomma: pk7, actions: renderActions.sofria2WebActions })
+        pk8.importDocument({ 'lang': 'eng', 'abbr': 'francl' }, 'usfm', usfm);
+        const docId = pk8.gqlQuerySync('{documents { id } }').data.documents[0].id;
+        const cl = new SofriaRenderFromProskomma({ proskomma: pk8, actions: renderActions.sofria2WebActions })
         const output = {}
         t.doesNotThrow(() => {
             cl.renderDocument({ docId, config, output })
         });
         t.ok("paras" in output);
-        t.ok(output.paras.includes("paras_usfm_f"));
+        t.ok(output.paras.includes("class=\"paras_usfm_p\""));
     } catch (err) {
         console.log(err);
     }

--- a/test/code/test_renderHtml.cjs
+++ b/test/code/test_renderHtml.cjs
@@ -125,6 +125,26 @@ test(`No extra commas around word markup (${testGroup})`, (t) => {
     }
 });
 
+test(`Footnote (${testGroup})`, (t) => {
+    t.plan(3);
+    try {
+        const pk7 = new Proskomma();
+        const usfm = fse.readFileSync(path.resolve(path.join('./', 'test', 'test_data', 'usfms', 'eng_francl_mrk.usfm'))).toString();
+        pk7.importDocument({ 'lang': 'eng', 'abbr': 'francl' }, 'usfm', usfm);
+        const docId = pk7.gqlQuerySync('{documents { id } }').data.documents[0].id;
+        const cl = new SofriaRenderFromProskomma({ proskomma: pk7, actions: renderActions.sofria2WebActions })
+        const output = {}
+        t.doesNotThrow(() => {
+            cl.renderDocument({ docId, config, output })
+        });
+        t.ok("paras" in output);
+        t.ok(output.paras.includes("paras_usfm_f"));
+    } catch (err) {
+        console.log(err);
+    }
+});
+
+
 test("Generate CSS (${testGroup})", t => {
     t.plan(4);
     let styleCss;


### PR DESCRIPTION
What the title says. Added a new test, all tests pass.