### PR TITLE
Replace braces one by one to handle aligned USFM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proskomma-json-tools",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Tools for working with Proskomma-derived formats such as PERF and SOFRIA",
   "main": "dist/index.js",
   "directories": {

--- a/src/render/sofria2web/sofria2html.js
+++ b/src/render/sofria2web/sofria2html.js
@@ -1,5 +1,5 @@
 const renderers = {
-    text: text => text.replace(/{([^}]+)}/g, (all, first) => `<i>${first}</i>`),
+    text: text => text.replace(/{/g, "<i>").replace(/}/g, "</i>"),
     chapter_label: number => `<span class="marks_chapter_label">${number}</span>`,
     verses_label: number => `<span class="marks_verses_label">${number}</span>`,
     paragraph: (subType, content, footnoteNo) => {


### PR DESCRIPTION
Last fix didn't work with uW USFM because the alignment data separates opening and closing braces into separate callbacks. This fix handles one brace at a time. Tests still pass.