### PR TITLE
Update SOFRIA renderers from jxl-pdf

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proskomma-json-tools",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Tools for working with Proskomma-derived formats such as PERF and SOFRIA",
   "main": "dist/index.js",
   "directories": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+
 const Validator = require('./validator');
 const usfmHelps = require('./usfmHelps');
 const usfmJsHelps = require('./usfmJsHelps');

--- a/src/render/sofria2web/sofria2html.js
+++ b/src/render/sofria2web/sofria2html.js
@@ -4,8 +4,19 @@ const renderers = {
     verses_label: number => `<span class="marks_verses_label">${number}</span>`,
     paragraph: (subType, content, footnoteNo) => {
         const paraClass = subType.split(':')[1];
-        const paraTag = ["f", "x"].includes(paraClass) ? "span" : "p";
-        return `<${paraTag} class="${`paras_usfm_${paraClass}`}">${content.join('')}</${paraTag}>`
+        let paraHtmlTag = "p";
+        if (["f", "x"].includes(paraClass)) {
+            paraHtmlTag = "span";
+        } else if (["s", "ms", "imt", "imte", "mt"].includes(paraClass)) {
+            paraHtmlTag = "h1";
+        } else if (["s2", "ms2", "imt2", "imte2", "mt2", "mr", "sr"].includes(paraClass)) {
+            paraHtmlTag = "h2";
+        } else if (["s3", "ms3", "imt3", "imte3", "mt3", "r", "d"].includes(paraClass)) {
+            paraHtmlTag = "h3";
+        } else if (["s4", "ms4",  "imt4", "imte4", "mt4"].includes(paraClass)) {
+            paraHtmlTag = "h4";
+        }
+        return `<${paraHtmlTag} class="${`paras_usfm_${paraClass}`}">${content.join('')}</${paraHtmlTag}>`
     },
     wrapper: (atts, subType, content) => subType === 'cell' ?
 
@@ -15,7 +26,7 @@ const renderers = {
             `<th colspan=${atts.nCols} style="text-align:${atts.alignment}">${content.join("")}</th>`
         :
 
-        `<span class="${`paras_usfm_${subType.split(':')[1]}`}">${content.join("")}</span>`,
+        `<span class="${`wrappers_usfm_${subType.split(':')[1]}`}">${content.join("")}</span>`,
     wWrapper: (atts, content) => Object.keys(atts).length === 0 ?
         content :
         `<span
@@ -37,6 +48,9 @@ const renderers = {
                         </div>`
         ).join('')
         }</span>`,
+    milestone: (tags, atts) => "", // Do not write milestones in HTML for now.
+    startChapters: nCols => `<section class="chapters" style="columns: ${nCols}">`,
+    endChapters: () => "</section>",
     mergeParas: paras => paras.join('\n'),
     row: (content) => {
         return (`<tr>${content.join("")}</tr>`)


### PR DESCRIPTION
This PR fixes various crashes and weird formatting around zaln milestones. It improves CSS, including dealing with widow titles. It adds control over the number of columns, whether to display the v1 label and whether to mark words in the glossary. All tests pass. To try it:

`node scripts/new_make_pdf.js json/psle.json`